### PR TITLE
Add esbuild-plugin-inline-worker to build process

### DIFF
--- a/@webwriter/build/build.js
+++ b/@webwriter/build/build.js
@@ -8,6 +8,7 @@ import {localize} from "./localize.js"
 import {document} from "./document.js"
 import 'dotenv/config'
 import esbuildPluginInlineImport from "esbuild-plugin-inline-import"
+import esbuildPluginInlineWorker from "esbuild-plugin-inline-worker";
 
 const scriptExtensions = [".js", ".mjs", ".cjs"]
 
@@ -73,7 +74,8 @@ async function main() {
     write: true,
     bundle: true,
     plugins: [
-      esbuildPluginInlineImport()
+      esbuildPluginInlineImport(),
+	  esbuildPluginInlineWorker()
       //widgetPlugin(pkg)
     ],
     entryPoints: buildableKeys.map(k => ({out: pkg.exports[k].default.replace(".*", "").replace(".js", ""), in: pkg.exports[k].source})),

--- a/@webwriter/build/package.json
+++ b/@webwriter/build/package.json
@@ -13,6 +13,7 @@
     "dotenv": "^16.4.5",
     "esbuild": "^0.25.4",
     "esbuild-plugin-inline-import": "^1.1.0",
+    "esbuild-plugin-inline-worker": "^0.1.1",
     "jsdom": "^25.0.1",
     "xliff": "^6.2.1"
   },


### PR DESCRIPTION
This adds [esbuild-plugin-inline-worker](https://github.com/mitschabaude/esbuild-plugin-inline-worker) to `@webwriter/build`, allowing you to write workers as ES modules with imports and use them like this:


**example.worker.ts**
```ts
import { foo } from "some-other-package";

console.log("Hello from worker", foo());
```

**widget.ts**
```ts
import ExampleWorker from "./example.worker";

new ExampleWorker();
```