### PR TITLE
Fix duplicate placeholder shown on multiple empty elements

### DIFF
--- a/@webwriter/core/model/schemas/resource/plugins/base.css
+++ b/@webwriter/core/model/schemas/resource/plugins/base.css
@@ -615,7 +615,7 @@ abbr {
 
 :is(:empty, :has(> :only-of-type.ProseMirror-trailingBreak)):not(
     .ProseMirror-widget
-  ):after {
+  ):first-child:after {
   font: inherit;
   text-align: inherit;
   content: var(--ww-placeholder);


### PR DESCRIPTION
Currently, a placeholder is shown for every empty element inside a slot which has the `--ww-placeholder` variable set (such as a quiz prompt or choice item):

<img width="831" height="249" alt="image" src="https://github.com/user-attachments/assets/c143aa10-f59f-48ba-bf81-80a5a34cb684" />

This change ensures that a placeholder is only displayed for the first empty element, rather than for each one:

<img width="831" height="249" alt="image" src="https://github.com/user-attachments/assets/0b5e627d-800c-4256-9719-06d34497dc35" />

I do not think that this will introduce any regressions in other widgets.